### PR TITLE
fix: Androidでシェアできない事象の対策

### DIFF
--- a/app/views/conversations/_ai_response.html.erb
+++ b/app/views/conversations/_ai_response.html.erb
@@ -7,7 +7,7 @@
 
       <%# --- X共有ボタン --- %>
       <% share_text = "「#{conversation.original_text}」を「#{suggestion.positive_text}」に言い換えました！\n#PosiRem\n" %>
-      <% x_share_url = "https://twitter.com/share?url=#{root_url}&text=#{ERB::Util.url_encode(share_text)}" %>
+      <% x_share_url = "https://twitter.com/intent/tweet?url=#{root_url}&text=#{ERB::Util.url_encode(share_text)}" %>
       <%= link_to x_share_url, target: "_blank", rel: "noreferrer", class: "btn btn-xs btn-natural btn-square text-secondary-content", data: { toggle: "tooltip", placement: "auto" }, title: "Xでシェア" do  %>
         <img src="/x-logo.svg" alt="Xでシェア" class="w-3 h-3 invert"/>
       <% end %>


### PR DESCRIPTION
## 概要
AndroidアプリでXにシェアできない事象の対策

## 関連issue
#44 

## やったこと
x_share_urlのurlを`https://twitter.com/intent/tweet`に修正
