### PR TITLE
fix: Xシェアボタンで引き渡されるURLが"https://example.org/"となる事象の調査

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,11 @@
 
   <body class="bg-base-200 flex flex-col min-h-screen" >
     <%= render "shared/header" %>
+    <div style="display: none;">
+      <p>root_url: <%= root_url %></p>
+      <p>request.base_url: <%= request.base_url %></p>
+      <p>request.host: <%= request.host %></p>
+    </div>
     <%= render 'shared/flash_message' %>
     <main class="flex-grow p-4 md:p-8 container mx-auto">
       <%= yield %>


### PR DESCRIPTION
## 概要
デバイスによって、Xシェアボタンで引き渡されるURLが"https://example.org/"となる事象の調査

## 関連issue
#44 

## やったこと
application.html.erbに調査用の非表示コードを埋め込み

## やらないこと
なし

## できるようになること(ユーザ目線)
なし

## できなくなること(ユーザ目線)
なし

## 影響範囲
なし

## 動作確認とその方法
なし

## その他