### PR TITLE
fix: root_ulrが正しく取得できない場合がある不具合の対応

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,21 +34,6 @@
 
   <body class="bg-base-200 flex flex-col min-h-screen" >
     <%= render "shared/header" %>
-    <div style="display: none;">
-      <p>root_url: <%= root_url %></p>
-      <p>request.base_url: <%= request.base_url %></p>
-      <p>request.host: <%= request.host %></p>
-      <%# 開発環境でのエラーを防ぐための安全な実装例 %>
-      <% host = ENV %> 
-      <%# または、デフォルト値を指定 %>
-      <% rehost = ENV.fetch('RENDER_EXTERNAL_HOSTNAME', 'test') %>
-      <p>rehost: <%= rehost %></p>
-      <%# 開発環境でのエラーを防ぐための安全な実装例 %>
-      <% reurl = ENV %>
-      <%# または、デフォルト値を指定 %>
-      <% reurl = ENV.fetch('RENDER_EXTERNAL_URL', 'test') %>
-      <p>reurl: <%= reurl %></p>
-    </div>
     <%= render 'shared/flash_message' %>
     <main class="flex-grow p-4 md:p-8 container mx-auto">
       <%= yield %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,4 +99,20 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # 1. Render環境変数からホスト名を取得し、設定がない場合は起動時にエラーを発生させる
+  #    これにより、ホスト名未設定によるexample.orgへのフォールバックを防止する。
+  host = ENV.fetch("RENDER_EXTERNAL_HOSTNAME")
+
+  # 2. Action ControllerのデフォルトURLオプション設定
+  config.action_controller.default_url_options = { host: host, protocol: "https" } # Render上のWebサービスは通常HTTPSであるため
+
+  # 3. Action MailerのデフォルトURLオプション設定 (非リクエストコンテキスト用)
+  config.action_mailer.default_url_options = { host: host, protocol: "https" }
+
+  # 4. Action Mailerの設定をグローバルなルートヘルパーのデフォルトにも反映
+  #    これにより、Action Mailer/Controllerの設定とは独立したActiveJobや他のコンテキストもカバーする。
+  Rails.application.routes.default_url_options.merge!(
+    config.action_controller.default_url_options
+  )
 end


### PR DESCRIPTION
## 概要
`root_url`が正しく取得できない場合がある不具合対応

## 関連issue
#44 

## やったこと
- 本番環境のホストネームをRenderのデフォルト環境変数`RENDER_EXTERNAL_HOSTNAME`から取得する
- 本番環境のURLの環境設定
