### PR TITLE
update: ログイン後の遷移先をチャット画面に変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,4 +11,8 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
+
+  def after_sign_in_path_for(resource)
+    conversations_path(format: :html)
+  end
 end


### PR DESCRIPTION
# 概要
<!-- 何を実装するかを簡潔に説明 -->
ログイン・アカウント登録後の画面の遷移先をチャット画面に変更

# やったこと
<!-- 実施内容を簡潔に -->
- ログイン・アカウント登録後の画面の遷移先をチャット画面に変更
- 画面遷移時のリクエストをhtmlに固定(Turbo Streamが誤動作しないようにするため)

# やらないこと
<!-- スコープ外の作業 -->
- なし

# できるようになること(ユーザ目線)
- ログイン・アカウント登録後にすぐに本サービスを使用できる

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- なし

# 動作確認とその方法
- [x] ログイン・アカウント登録後にチャット画面に遷移できること

# その他
<!-- 何かあれば -->
なし