### PR TITLE
update: バリデーションエラー発生箇所のハイライト表示を追加

### DIFF
--- a/app/assets/stylesheets/field_errors.css
+++ b/app/assets/stylesheets/field_errors.css
@@ -1,0 +1,17 @@
+/* バリデーションエラー時の field_with_errors ラッパーによるレイアウト崩れを防止 */
+.field_with_errors {
+  display: contents;
+}
+
+/* バリデーションエラー時の label スタイル: 太字・赤色・アンダーライン */
+.field_with_errors label {
+  font-weight: bold;
+  color: var(--color-error);
+  text-decoration: underline;
+}
+
+/* バリデーションエラー時の input / textarea スタイル: 枠を赤色 */
+.field_with_errors input,
+.field_with_errors textarea {
+  border-color: var(--color-error);
+}


### PR DESCRIPTION
# 概要
バリデーションエラー発生時に、エラー該当フィールドを視覚的にハイライト表示する。
また、Rails デフォルトの `field_with_errors` ラッパーによる表示崩れを解消する。

# 関連issue
close #108 

# やったこと
- `field_with_errors` の `<div>` ラッパーに `display: contents` を適用し、表示崩れを解消
- エラー該当フィールドの label に太字・赤色・アンダーラインのスタイルを追加
- エラー該当フィールドの input / textarea の枠を赤色に変更
- 上記スタイルを `app/assets/stylesheets/field_errors.css` として新規作成

# やらないこと
- ビュー（ERB）側の変更（CSS のみで完結）
- エラーメッセージ表示（フォーム上部のアラート）の変更

# できるようになること(ユーザ目線)
- バリデーションエラー時に、どのフィールドでエラーが発生したか視覚的に判別できるようになる
- フォームのレイアウト崩れが解消される

# できなくなること(ユーザ目線)
- なし

# 影響範囲
- 新規登録フォーム（`devise/registrations/new`）
- アカウント編集フォーム（`devise/registrations/edit`）
- ログインフォーム（`devise/sessions/new`）
- 会話入力フォーム（`conversations/_form`）
- その他 `form_for` / `form_with` を使用する全フォーム

# 動作確認とその方法
- [x] `field_with_errors` の `<div>` ラッパーに `display: contents` が適用され、表示崩れが解消されている
- [x] バリデーションエラー時、エラー該当フィールドの label が太字・赤色・アンダーラインになる
- [x] バリデーションエラー時、エラー該当フィールドの input / textarea の枠が赤色になる
- [x] 既存のエラーメッセージ表示（フォーム上部のアラート）に影響がない
- [x] RuboCop が通る

# その他
- `field_with_errors` クラスを CSS セレクタとして活用することで、ビュー側の変更なしに実装


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル

* フォームのバリデーションエラー表示時のビジュアルを改善しました。エラーが発生した場合、ラベルは太字・赤色・下線付きで表示され、入力フィールドの枠線が赤色になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->